### PR TITLE
Multi Select Dropdown / Auto-Reset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Renamed `data-mtl="side-nav"` to `data-mtl-nav="side"`
+- Added `data-mtl-select` and `data-mtl-select="multiple"`, #6
+- Added MTL.onReady/onTurbolinksLoad JS helpers to skip duplicate calls
+  or first call when turbolinks is used
 - Improve hooks.coffee with a simple turbolinks guard, to ensure it
   is only called once on initial page load. Also added turbolink hook
   for Waves.displayEffect()

--- a/app/assets/javascripts/mtl.js
+++ b/app/assets/javascripts/mtl.js
@@ -21,4 +21,6 @@
 //=require "materialize/date_picker/picker"
 //=require "materialize/date_picker/picker.date"
 
+//= require "mtl/turbolinks"
 //= require "mtl/hooks"
+//= require "mtl/select"

--- a/app/assets/javascripts/mtl/hooks.coffee
+++ b/app/assets/javascripts/mtl/hooks.coffee
@@ -1,29 +1,10 @@
 # Hooks for Turbolinks / jQuery et all
 
-skipSecond = (cb) ->
-  cntr = 0
-  ->
-    cntr += 1
-    cb() if cntr != 2
+MTL.onReady ->
+  # Hooks to data-mtl-nav
+  $('[data-mtl-nav="side"]').each -> $(this).sideNav()
 
-skipFirst = (cb) ->
-  cntr = 0
-  ->
-    cntr += 1
-    cb() if cntr > 1
-
-initSideNavs = ->
-  $('[data-mtl="side-nav"]').each -> $(this).sideNav()
-
-initFormLabels = ->
+# Things to run only once via on('ready') and need to be re-run in turbolinks
+MTL.onTurbolinksLoad ->
   Materialize.updateTextFields()
-
-initWaves = ->
   Waves.displayEffect()
-
-$(document).on 'ready turbolinks:load', skipSecond ->
-  initSideNavs()
-
-$(document).on 'turbolinks:load', skipFirst ->
-  initFormLabels()
-  initWaves()

--- a/app/assets/javascripts/mtl/select.coffee
+++ b/app/assets/javascripts/mtl/select.coffee
@@ -1,0 +1,38 @@
+prepareSelect = ($el) ->
+  val = $el.val()
+  index = $el.prop('selectedIndex')
+
+  if !val || val.length == 0 || index == 0
+    $el.prop('selectedIndex', 0)
+    $el.data('mtl-select:is-all-selected', true)
+
+  $el
+
+createSelectCallback = ($el) ->
+  ->
+    return unless $el.data('mtl-select') == "multiple"
+
+    $dropdown = $el.prev('.multiple-select-dropdown')
+    val = $el.val()
+    index = $el.prop('selectedIndex')
+    isSelected = $el.data('mtl-select:is-all-selected')
+
+    # 1: Nothing has been selected => select "all"
+    if !val || val.length == 0
+      $el.data('mtl-select:is-all-selected', true)
+      $dropdown.find('li:first').trigger('click')
+    # 2: More than one item is selected and previously "all" was selected =>
+    #    disable select "all"
+    else if val.length > 1 && isSelected
+      $el.data('mtl-select:is-all-selected', false)
+      $dropdown.find('li:first').trigger('click')
+    # 3: More than one item is selected and previously "all" was not selected =>
+    #    select "all" again
+    else if val.length > 1 && index == 0
+      $el.data('mtl-select:is-all-selected', true)
+      $dropdown.find('li.active:not(:first)').trigger('click')
+
+MTL.onReady ->
+  $('select[data-mtl-select]').each ->
+    $this = prepareSelect $(this)
+    $this.material_select(createSelectCallback($this))

--- a/app/assets/javascripts/mtl/turbolinks.coffee
+++ b/app/assets/javascripts/mtl/turbolinks.coffee
@@ -1,0 +1,12 @@
+skipNth = (nth, cb) ->
+  cntr = 0
+  ->
+    cb() unless cntr == nth
+    cntr += 1
+
+@MTL ?= {}
+@MTL.onReady = (cb) ->
+  $(document).on 'ready turbolinks:load', skipNth(1, cb)
+
+@MTL.onTurbolinksLoad = (cb) ->
+  $(document).on 'turbolinks:load', skipNth(0, cb)

--- a/app/views/mtl/header.html.erb
+++ b/app/views/mtl/header.html.erb
@@ -6,7 +6,7 @@
           <i class="material-icons">arrow_back</i>
         <%- end %>
       <%- elsif mtl_menu %>
-        <%= link_to "##{mtl_menu}", class: 'mtl-layout-default-header-toggle left hide-on-large-only', 'data-activates': mtl_menu, 'data-mtl': 'side-nav' do %>
+        <%= link_to "##{mtl_menu}", class: 'mtl-layout-default-header-toggle left hide-on-large-only', 'data-activates': mtl_menu, 'data-mtl-nav': 'side' do %>
           <i class="material-icons">menu</i>
         <%- end %>
       <%- end %>

--- a/spec/mtl/rails/header_helper_spec.rb
+++ b/spec/mtl/rails/header_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Mtl::Rails::HeaderHelper, dom: true do
         <header class="mtl-layout-default-header">
           <nav>
             <div class="nav-wrapper">
-              <a class="mtl-layout-default-header-toggle left hide-on-large-only" data-activates="nav-menu" data-mtl="side-nav" href="#nav-menu">
+              <a class="mtl-layout-default-header-toggle left hide-on-large-only" data-activates="nav-menu" data-mtl-nav="side" href="#nav-menu">
                 <i class="material-icons">menu</i>
               </a>
               <h1 class="page-title">Dashboard</h1>


### PR DESCRIPTION
This PR adds the glue JavaScript code to automatically initialize any `<select>` using the materializecss `.materialize_select()` method. In addition it adds logic on top to correctly select / deselect items, for when a "reset" is required with in a situation like the following:

```html
<select multiple data-mtl-select="multiple">
  <option value="">All items</option>
  <option value="1">First item</option>
  <option value="2">Second item</option>
</select>
```

So it properly selects / deselects the first element, but only when `data-mtl-select="multiple"` is used!

### Demo

![multi](https://cloud.githubusercontent.com/assets/83660/16420864/40b28690-3d53-11e6-8cc2-8b6917f35d75.gif)

### Syntax

```html
<!-- Default dropdown -->
<select data-mtl-select>
  <option>First</option>
  <option>Second</option>
</select>

<!-- With "reset-to-first" feature -->
<select multiple data-mtl-select="multiple">
  <option value="">All</option> <!-- value MUST BE "" -->
  <option>First</option>
  <option>Second</option>
</select>
```