### PR TITLE
Added #mtl_icon helper + simple_form.rb generator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ AllCops:
     - 'bin/*'
     - 'node_modules/**'
     - 'node_modules/**/*'
+    - 'vendor/**'
+    - 'vendor/**/*'
 
   # Cop names are not displayed in offense messages by default. Change behavior
   # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
@@ -34,6 +36,10 @@ Style/Documentation:
     - lib/materializer.rb
     - spec/*
     - spec/**/*
+
+Style/ClassVars:
+  Exclude:
+    - lib/mtl.rb
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -16,6 +16,8 @@ linters:
   SelectorFormat:
     enabled: true
     convention: hyphenated_BEM
+    exclude:
+      - app/assets/stylesheets/mtl/extend/_forms.scss
   MergeableSelector:
     enabled: false
   ImportantRule:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+cache:
+  directories:
+    - vendor/bundle
+    - node_modules
 rvm:
   - 2.2.0
   - 2.3.1
@@ -9,6 +13,6 @@ before_install:
   - nvm use 6
   - node -v
 install:
-  - bundle install
+  - bundle install --jobs=3 --retry=3 --path vendor/bundle
   - npm install
 script: ./bin/ci

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,18 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Added configuration option for effects: `Mtl.effects`, they default to
+  `waves-effect waves-light` and are used by all buttons [#7]
+- Added `mtl_button` and `mtl_button_flat` helper methods, when using: prefer
+  the `mtl_button_flat` method [#7]
+- Added `mtl_icon(:cloud)` (alias: `mi`) icon helper to render
+  `<i class="material-icons">cloud</i>` tags [#7]
+- Added `simple_form.rb` initializer to generator, that creates a basic useable
+  simple form configuration, based on
+  [patricklindsay/simple_form-materialize](https://github.com/patricklindsay/simple_form-materialize)
+  [#5, #7]
 - Renamed `data-mtl="side-nav"` to `data-mtl-nav="side"`
-- Added `data-mtl-select` and `data-mtl-select="multiple"`, #6
+- Added `data-mtl-select` and `data-mtl-select="multiple"`, [#6]
 - Added MTL.onReady/onTurbolinksLoad JS helpers to skip duplicate calls
   or first call when turbolinks is used
 - Improve hooks.coffee with a simple turbolinks guard, to ensure it
@@ -17,3 +27,4 @@ Development 0.1.0
   that uses the embedded icon font and already contains the additional flags
 - Added material-design-icon font from npm, to provide the icon font locally
 - Updated to Dogfalo/materialize@607951e
+

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ $> bundle
 And finally run the installer to copy the "base files" to your application:
 
 ```
-$> ./bin/rails generate mtl:install
+$> ./bin/rails generate mtl:install [--skip-simple-form]
 # This copies the following files:
 #    - app/assets/stylesheets/mtl.scss
 #    - app/assets/stylesheets/mtl/_color.scss
 #    - app/assets/stylesheets/mtl/_variables.scss
+#    - config/initializers/simple_form.rb
 ```
 
 Last but not least change your `application.css` to include:
@@ -61,6 +62,22 @@ and details, but a quick and dirty usage to render a navbar header is:
 ```haml
 = mtl_header t('.title'), back: dossiers_path do
   = render 'filters'
+```
+
+**Buttons**, see [button_helper.rb][button_helper.rb] for details, these helpers
+allow to render raised and flat buttons and basically wrap `link_to`:
+```haml
+= mtl_button 'Next', some_path
+= mtl_button_flat 'Cancel', some_path
+```
+
+**Icons**, see [icon_helper.rb][icon_helper.rb] for additional docs, but this
+helper is rather simple - it simply renders those `<i class="material-icons">..</i>`
+tags:
+```haml
+= mtl_icon :cloud
+= mtl_icon :send, class: 'right red'
+= mtl_icon :send, size: 'large'
 ```
 
 ## Development

--- a/app/assets/stylesheets/mtl/all.scss
+++ b/app/assets/stylesheets/mtl/all.scss
@@ -36,6 +36,7 @@
 
 @import 'materialize/materialbox';
 @import 'materialize/forms/forms';
+@import './extend/forms';
 @import 'materialize/table_of_contents';
 
 @import 'materialize/sideNav';

--- a/app/assets/stylesheets/mtl/extend/_forms.scss
+++ b/app/assets/stylesheets/mtl/extend/_forms.scss
@@ -1,0 +1,4 @@
+.simple_form .check_boxes > label,
+.simple_form .radio_buttons > label {
+  display: none;
+}

--- a/lib/generators/mtl/install_generator.rb
+++ b/lib/generators/mtl/install_generator.rb
@@ -4,11 +4,15 @@ module Mtl
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
       source_root File.join File.dirname(__FILE__), 'templates'
+      class_option :simple_form, type: :boolean, default: true
 
       def copy_stylesheets
         template 'mtl.scss',        'app/assets/stylesheets/mtl.scss'
         template '_color.scss',     'app/assets/stylesheets/mtl/_color.scss'
         template '_variables.scss', 'app/assets/stylesheets/mtl/_variables.scss'
+
+        return unless options['simple_form']
+        template 'simple_form.rb', 'config/initializers/simple_form.rb'
       end
     end
   end

--- a/lib/generators/mtl/templates/simple_form.rb
+++ b/lib/generators/mtl/templates/simple_form.rb
@@ -1,0 +1,208 @@
+# Copyright 2016 Patrick Lindsay
+# https://github.com/patricklindsay/simple_form-materialize
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :material_checkbox,
+                  hint_class: :field_with_hint, error_class: 'has-error' do |b|
+    b.use :input
+    b.use :label
+
+    b.use :hint,  wrap_with: { tag: :span, class: 'help-block' }
+    b.use :error, wrap_with: { tag: :span, class: 'error-block' }
+
+    b.use :html5
+  end
+
+  config.wrappers :disabled_form do |b|
+    b.use :label
+    b.use :input, disabled: true, readonly: true
+  end
+
+  config.wrappers :default, class: 'input-field col s12',
+                            hint_class: :field_with_hint, error_class: 'has-error' do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    b.use :maxlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.use :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    b.use :input
+    b.use :label
+
+    b.use :hint,  wrap_with: { tag: :span, class: 'help-block' }
+    b.use :error, wrap_with: { tag: :span, class: 'error-block' }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :inline
+
+  # Default class for buttons
+  config.button_class = "btn #{Mtl.effects}"
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'alert alert-danger'
+
+  # ID to add for error notification helper.
+  # config.error_notification_id = nil
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span. Please note that when using :boolean_style = :nested,
+  # SimpleForm will force this option to be a label.
+  config.item_wrapper_tag = :p
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Collection of methods to detect if a file type was given.
+  # config.file_methods = [ :mounted_as, :file?, :public_filename ]
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  config.wrapper_mappings = {
+    switch: :material_checkbox
+  }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+end

--- a/lib/mtl.rb
+++ b/lib/mtl.rb
@@ -1,8 +1,16 @@
 require 'rails'
 require 'mtl/version'
-require 'mtl/rails/header_helper'
 
+require 'mtl/rails/button_helper'
+require 'mtl/rails/header_helper'
+require 'mtl/rails/icon_helper'
+
+# MTL configuration options are as follows:
 module Mtl
+  # CSS classes added for effects on buttons
+  mattr_accessor :effects
+  @@effects = 'waves-effect waves-light'
+
   #:nodoc:
   class Engine < ::Rails::Engine
     initializer 'mtl.assets.precompile' do |app|
@@ -12,7 +20,9 @@ module Mtl
     end
 
     initializer 'mtl.view_helpers' do
+      ActionView::Base.send :include, Mtl::Rails::ButtonHelper
       ActionView::Base.send :include, Mtl::Rails::HeaderHelper
+      ActionView::Base.send :include, Mtl::Rails::IconHelper
     end
   end
 end

--- a/lib/mtl/rails/button_helper.rb
+++ b/lib/mtl/rails/button_helper.rb
@@ -1,0 +1,27 @@
+module Mtl
+  module Rails
+    # Buttons
+    # =======
+    #
+    # Helper methods to create both raised and flat buttons by wrapping the
+    # original Rails `link_to` helper method.
+    #
+    # **Examples**
+    # ```erb
+    # <%= mtl_button "New", new_user_path # create a raised button %>
+    # <%= mtl_button_flat "Delete", user_path(@user), method: :delete # create a flat button %>
+    # ```
+    #
+    module ButtonHelper
+      def mtl_button_flat(text, url, options = {})
+        options[:class] = ['btn-flat', options[:class]].compact
+        mtl_button text, url, options
+      end
+
+      def mtl_button(text, url, options = {})
+        options[:class] = ['btn', Mtl.effects, options[:class]].compact
+        link_to text, url, options
+      end
+    end
+  end
+end

--- a/lib/mtl/rails/icon_helper.rb
+++ b/lib/mtl/rails/icon_helper.rb
@@ -1,0 +1,24 @@
+module Mtl
+  module Rails
+    # Icon Helper
+    # ===========
+    #
+    # Small helper to render icons using the materialize font.
+    #
+    # **Examples**
+    # ```erb
+    # <%= mtl_icon :cloud # renders a "cloud" icon %>
+    # <%= mtl_icon :cloud, size: :large # renders a large cloud icon %>
+    #
+    # <%= mtl_icon :alert, class: 'right red' # add custom classes %>
+    # ```
+    module IconHelper
+      ICON_CLASS = 'material-icons'.freeze
+
+      def mtl_icon(icon, options = {})
+        options[:class] = [ICON_CLASS, options.delete(:size), options[:class]].compact
+        content_tag :i, icon, options
+      end
+    end
+  end
+end

--- a/spec/mtl/rails/button_helper_spec.rb
+++ b/spec/mtl/rails/button_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'action_view'
+require 'mtl/rails/button_helper'
+
+RSpec.describe Mtl::Rails::ButtonHelper, dom: true do
+  subject { ActionView::Base.new }
+  before { subject.send(:extend, described_class) }
+
+  context '#mtl_button' do
+    it 'renders an <a/> tag as a raised button (.btn)' do
+      expect(subject.mtl_button('Save', '/some/url'))
+        .to eq '<a class="btn waves-effect waves-light" href="/some/url">Save</a>'
+    end
+
+    it 'passes in other option to #link_to' do
+      expect(subject.mtl_button('Save', '/some/url', class: 'red', method: :delete))
+        .to eq '<a class="btn waves-effect waves-light red" rel="nofollow" data-method="delete" href="/some/url">Save</a>'
+    end
+
+    it 'uses Mtl.effects for the effects' do
+      allow(Mtl).to receive(:effects) { 'waves-effect waves-red' }
+      expect(subject.mtl_button('Save', '/some/url'))
+        .to eq '<a class="btn waves-effect waves-red" href="/some/url">Save</a>'
+    end
+  end
+
+  context '#mtl_button_flat' do
+    it 'renders an <a/> tag as a flat button (.btn-flat) [delegates to #mtl_button]' do
+      expect(subject.mtl_button_flat('Cancel', '/some/url'))
+        .to eq '<a class="btn waves-effect waves-light btn-flat" href="/some/url">Cancel</a>'
+    end
+  end
+end

--- a/spec/mtl/rails/icon_helper_spec.rb
+++ b/spec/mtl/rails/icon_helper_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'action_view'
+require 'mtl/rails/icon_helper'
+
+RSpec.describe Mtl::Rails::IconHelper, dom: true do
+  subject { ActionView::Base.new }
+  before { subject.send(:extend, described_class) }
+
+  context '#mtl_icon' do
+    it 'renders an icon' do
+      expect(subject.mtl_icon(:cloud)).to eq '<i class="material-icons">cloud</i>'
+    end
+
+    it 'pass in the size' do
+      expect(subject.mtl_icon(:cloud, size: 'large')).to eq '<i class="material-icons large">cloud</i>'
+    end
+
+    it 'can pass in custom options like class' do
+      expect(subject.mtl_icon(:cloud, class: 'right')).to eq '<i class="material-icons right">cloud</i>'
+    end
+  end
+end


### PR DESCRIPTION
In the wake of fixing #5 I did the following:

- [x] Create a proper `simple_form.rb` configuration that should (!) work in most cases
- [x] Added the `mtl_icon` helper to reference icons
- [x] Added `mtl_button*` helpers to render link_to as flat / raised buttons

The proper simple form syntax to create a submit button is, this creates a button with the icon

```haml
.row
  .col.right
    = mtl_button_flat 'Cancel', users_path # render the "Cancel" button (flat style)
    = f.button :button, 'Save' # Render the "Save" button (raised style)
```

![buttons](https://cloud.githubusercontent.com/assets/83660/16466943/54ffa360-3e45-11e6-81e4-8ca25a12a574.gif)

@sled and @marcopluess please review and merge, danke.

PS: For styling / usage, please read up on https://material.google.com/components/buttons.html, e.g. I'm not sure if in my example above all buttons should be raised (or at least the delete too?) /cc @florianwestermann - maybe it's "Cancel" => flat, "Delete" => raised + red, "Submit" => raised + primary