### PR TITLE
Refactored hooks.coffee and added hook for waves

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Improve hooks.coffee with a simple turbolinks guard, to ensure it
+  is only called once on initial page load. Also added turbolink hook
+  for Waves.displayEffect()
 - Renamed `materializer` to `mtl`
 - Added `materializer_header` helper function to render nice navbars
 - REPLACE: vendored `_icons-material-design.scss` with local `_material-icons.scss`,

--- a/app/assets/javascripts/mtl/hooks.coffee
+++ b/app/assets/javascripts/mtl/hooks.coffee
@@ -1,8 +1,29 @@
 # Hooks for Turbolinks / jQuery et all
 
+skipSecond = (cb) ->
+  cntr = 0
+  ->
+    cntr += 1
+    cb() if cntr != 2
+
+skipFirst = (cb) ->
+  cntr = 0
+  ->
+    cntr += 1
+    cb() if cntr > 1
+
 initSideNavs = ->
   $('[data-mtl="side-nav"]').each -> $(this).sideNav()
 
-event = if window.Turbolinks? then 'turbolinks:load' else 'ready'
-$(document).on event, ->
+initFormLabels = ->
+  Materialize.updateTextFields()
+
+initWaves = ->
+  Waves.displayEffect()
+
+$(document).on 'ready turbolinks:load', skipSecond ->
   initSideNavs()
+
+$(document).on 'turbolinks:load', skipFirst ->
+  initFormLabels()
+  initWaves()


### PR DESCRIPTION
This PR adds a guard to ensure that on initial page and subsequent page loads (with or without turbolinks) correctly hooks up the JS behaviours from materialize-css, without calling the methods too many times.

@lgavillet or @sled please review and merge, thanks.