### PR TITLE
Enhance dropdowns within .simple_form container

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Auto-enhance `<select>`s within simple form `<form>`s [#27]
 - Added reference to Mtl::Rails::ViewHelpers, improved documentation on
   .fixed-action-btn within the default layout
 - Added `data-mtl-collapsible` and `data-mtl-collapsible-toggle`s [#22, #24]

--- a/app/assets/javascripts/mtl/select.coffee
+++ b/app/assets/javascripts/mtl/select.coffee
@@ -33,6 +33,6 @@ createSelectCallback = ($el) ->
       $dropdown.find('li.active:not(:first)').trigger('click')
 
 MTL.onReady ->
-  $('select[data-mtl-select]').each ->
+  $('select[data-mtl-select], .simple_form .input-field.select > select.select').each ->
     $this = prepareSelect $(this)
     $this.material_select(createSelectCallback($this))


### PR DESCRIPTION
This change fixes `<select/>` dropdowns within .simple_form `<form>`'s. Otherwise each select input requires additional manual markup like:

```haml
= f.input :field, collection: c, input_html: { 'data-mtl-select': true }
```

This change makes this obsolete.

@lgavillet or @marcopluess please review and merge, thanks.