### PR TITLE
Added support for modal windows with XHR support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Added support for modals via `data-mtl-modal`
 - Auto-enhance `<select>`s within simple form `<form>`s [#27]
 - Added reference to Mtl::Rails::ViewHelpers, improved documentation on
   .fixed-action-btn within the default layout

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -135,6 +135,8 @@ The following JS helpers from [Materialize CSS][materialize] are supported:
 - Text fields (support for Turbolinks)
 - Mobile navigation: `data-mtl-nav`
 - Select fields: `data-mtl-select`
+- Collapsibles: `data-mtl-collapsible`
+- Modals: `data-mtl-modal`
 
 **Note:** at the time of writing not all JS helpers are supported. New wrappers
 are added step by step over time.
@@ -255,7 +257,61 @@ by default the first item is open.
 </ul>
 ```
 
-### `data-mtl-href` Utility
+### Modals
+
+Based on leanModal MTL adds turbolinks support as well as loading content over
+XHR GET requests. This can be used to render partials into modal windows. For
+markup details of the modal itself, please refer to the
+[Materialize CSS: Modals][m-modals] documentation.
+
+#### Simple modals
+
+A modal usually consists of a trigger (via `data-mtl-modal="default"`) and the
+corresponding modal content.
+
+```html
+<!-- Use data-mtl-modal="default" to enable as trigger, uses href or data-target -->
+<a href="#modal" class="btn-flat" data-mtl-modal="default">Open Modal</a>
+
+<div class="modal">
+  <div class="modal-content">
+    <h4>Your modal</h4>
+    <p>Example modal.</p>
+  </div>
+  <div class="modal-footer">
+    <!-- Use data-mtl-modal="close" to add a close button -->
+    <a href="#close" class="btn-flat modal-action" data-mtl-modal="close">
+      Close
+    </a>
+  </div>
+</div>
+```
+
+#### XHR modals
+
+To load content for the modal via XHR the trigger must be created as usual
+with the `data-mtl-modal="xhr"` marker. The `href` in that case indicates the
+resource to load via `$.load`. Behind the scenes an empty modal is generated,
+that is loaded on open. No additional markup is required in that case.
+
+```html
+<a href="/your_controller/assignees" data-mtl-modal="xhr">
+  Change assignee
+</a>
+```
+
+The (Rails) controller should be configured to only return a partial. The partial
+can contain `data-mtl-modal="close"` triggers too.
+
+```ruby
+# Rails: your_controller.rb
+def assignees_modal
+  @assignees = context.assignees
+  render partial: 'assignees_modal'
+end
+```
+
+### Helper: `data-mtl-href`
 
 This utility helps linking rows from a table or ul to open a detail page.
 
@@ -279,3 +335,4 @@ This utility helps linking rows from a table or ul to open a detail page.
 [m-collapsible]: http://materializecss.com/collapsible.html
 [m-icons]: http://materializecss.com/icons.html
 [m-buttons]: http://materializecss.com/buttons.html
+[m-modals]: http://materializecss.com/modals.html

--- a/app/assets/javascripts/mtl.js
+++ b/app/assets/javascripts/mtl.js
@@ -22,7 +22,9 @@
 //=require "materialize/date_picker/picker.date"
 
 //= require "mtl/turbolinks"
-//= require "mtl/href"
 //= require "mtl/hooks"
-//= require "mtl/select"
+
+//= require "mtl/href"
 //= require "mtl/collapsible"
+//= require "mtl/modal"
+//= require "mtl/select"

--- a/app/assets/javascripts/mtl/modal.coffee
+++ b/app/assets/javascripts/mtl/modal.coffee
@@ -1,0 +1,31 @@
+MODAL_IDS = 1
+MODAL_TEMPLATE = '
+<div class="modal">
+  <div class="modal-content modal-loading">
+    Loading&hellip;
+  </div>
+</div>
+'
+
+initModal = ($el) ->
+  return initXhrModal($el) if $el.data('mtl-modal') == 'xhr'
+  return initDefaultModal($el) if $el.data('mtl-modal') == 'default'
+
+initXhrModal = ($el) ->
+  modalId = 'mtl-modal-' + (MODAL_IDS++)
+  ds = $el.prop('href')
+  $modal = $(MODAL_TEMPLATE).prop('id', modalId)
+  $modal.insertAfter($el)
+  $el.prop('href', "##{modalId}")
+
+  initDefaultModal $el,
+    ready: -> $modal.load(ds)
+
+initDefaultModal = ($el, options = {}) -> $el.leanModal(options)
+
+$(document).on 'click', '[data-mtl-modal="close"]', (e) ->
+  e.preventDefault()
+  $(this).parents('.modal:first').closeModal()
+
+MTL.onReady ->
+  $('[data-mtl-modal]').each -> initModal($(this))


### PR DESCRIPTION
Using `data-mtl-modal=...` can be used to open modal windows using `leanModal()` from Materialize. On top of it support for loading content from XHR has been added.

### Simple example

```haml
= mtl_button_flat 'Default Modal', '#modal', 'data-mtl-modal': 'default'

#modal.modal
  .modal-content
    Hi, I'm a modal window with local content
  .modal-footer
    = mtl_button_flat 'Close', '#close', class: 'modal-action', 'data-mtl-modal': 'close'
```

### XHR example

Loading content from XHR is just as simple, in that case a corresponding .modal is auto-generated and inserted directly after the button itself. The content is loaded each time the modal is opened using `$.load`.

```haml
= mtl_button_flat 'XHR Modal', your_resource_path, 'data-mtl-modal': 'xhr'
```

There is a very simple and ugly, default loading template already existing, can be customized by styling `.modal-content.modal-loading`

**Update** for the XHR, you have to ensure to return a partial of course...

@sled and @lgavillet please review, check the documentation and give feedback, thanks.