### PR TITLE
Properly destroy select before turbolinks caching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Properly teardown data-mtl-select on turbolinks:before-cache #34
 - Add border-radius to .avatar > img to avoid flickering
 - Removed MTL.xyz magic, because it really is not required, required a fix
   for http://jquery.com/upgrade-guide/3.0/#breaking-change-on-quot-ready-quot-fn-removed

--- a/app/assets/javascripts/mtl/select.coffee
+++ b/app/assets/javascripts/mtl/select.coffee
@@ -36,4 +36,9 @@ init = ->
   $('select[data-mtl-select], .simple_form .input-field.select > select.select').each ->
     $this = prepareSelect $(this)
     $this.material_select(createSelectCallback($this))
+
+teardown = ->
+  $('select.initialized').each -> $(this).material_select('destroy')
+
 if Turbolinks? then $(document).on('turbolinks:load', init) else $(init)
+$(document).on 'turbolinks:before-cache', teardown


### PR DESCRIPTION
This fixes the double <select> rendering when using back / forward
browser buttons.

Fixes #34

@ruinunes please test and merge, thanks.