### PR TITLE
Enables automatic ToC via data-mtl-toc/section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Implement ToC based on pushpin and scrollspy [#36]
+  This introduces a two new variables to properly style ToCs,
+  these are $mtl-toc-text and $mtl-toc-border
 - Properly teardown data-mtl-select on turbolinks:before-cache #34
 - Add border-radius to .avatar > img to avoid flickering
 - Removed MTL.xyz magic, because it really is not required, required a fix

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -240,6 +240,7 @@ The following JS helpers from [Materialize CSS][materialize] are supported:
 - Tabs: `data-mtl-tabs`
 - Collapsibles: `data-mtl-collapsible`
 - Modals: `data-mtl-modal`
+- Pinned table of contents (with scrollSpy): `data-mtl-toc`
 
 **Note:** at the time of writing not all JS helpers are supported. New wrappers
 are added step by step over time.
@@ -425,6 +426,35 @@ def assignees_modal
 end
 ```
 
+### Table of Contents
+
+Based on the provided [scrollspy][m-scrollspy] and [pushpin][m-pushpin] methods
+the MTL table of content behaviour automatically creates a dynamic ToC, based on
+the current page content.
+
+A ToC entry is indicated by adding `data-mtl-section="Title"` and then is
+automatically added in the order of appearance on the site to the
+`ul[data-mtl-toc]` element. Any content within `data-mtl-toc` is completely
+replaced.
+
+```html
+<div class="row" data-mtl-section="Introduction">
+  <!-- content -->
+</div>
+<div class="row" data-mtl-section="Structure">
+  <!-- content -->
+</div>
+<div class="row" data-mtl-section="Other">
+  <!-- content -->
+</div>
+
+<!-- ToC element: an empty ul with class="table-of-contents" -->
+<ul class="table-of-contents" data-mtl-toc="pin"></ul>
+```
+
+Using `data-mtl-toc="pin"` makes use of the pushpin plugin to pin the ToC
+element to the top of the screen.
+
 ### Helper: `data-mtl-href`
 
 This utility helps linking rows from a table or ul to open a detail page.
@@ -451,3 +481,5 @@ This utility helps linking rows from a table or ul to open a detail page.
 [m-buttons]: http://materializecss.com/buttons.html
 [m-modals]: http://materializecss.com/modals.html
 [m-tabs]: http://materializecss.com/tabs.html
+[m-scrolllspy]: http://materializecss.com/scrolllspy.html
+[m-pushpin]: http://materializecss.com/pushpin.html

--- a/app/assets/javascripts/mtl.js
+++ b/app/assets/javascripts/mtl.js
@@ -20,9 +20,11 @@
 //=require "materialize/slider"
 //=require "materialize/date_picker/picker"
 //=require "materialize/date_picker/picker.date"
+//=require "materialize/pushpin"
 
 //= require "mtl/hooks"
 //= require "mtl/href"
 //= require "mtl/collapsible"
 //= require "mtl/modal"
 //= require "mtl/select"
+//= require "mtl/toc"

--- a/app/assets/javascripts/mtl/toc.coffee
+++ b/app/assets/javascripts/mtl/toc.coffee
@@ -1,0 +1,31 @@
+TEMPLATE = _.template '''
+<li>
+  <a href="#<%- id %>"><%- title %></a>
+</li>
+'''
+
+createTocEntry = ($el) ->
+  # Ensure id and get title
+  title = $el.data('mtl-section')
+  id = $el.prop('id') || "mtl-toc-#{Materialize.guid()}"
+  $el.prop('id', id)
+
+  # Render
+  TEMPLATE(id: id, title: title)
+
+initToc = ($wrapper) ->
+  # Clear
+  $wrapper.children().remove()
+
+  # Pin wrapper to top, if data-mtl-toc="pin"
+  $wrapper.pushpin(top: $wrapper.offset().top) if $wrapper.data('mtl-toc') == 'pin'
+
+  # Add entries
+  $sections = $('[data-mtl-section]').each ->
+    $wrapper.append createTocEntry($(this))
+
+  # Enable scrollspy
+  $sections.scrollSpy()
+
+init = -> $('[data-mtl-toc]').each -> initToc($(this))
+if Turbolinks? then $(document).on('turbolinks:load', init) else $(init)

--- a/app/assets/stylesheets/mtl/all.scss
+++ b/app/assets/stylesheets/mtl/all.scss
@@ -42,6 +42,7 @@
 @import 'materialize/forms/forms';
 @import './extend/forms';
 @import 'materialize/table_of_contents';
+@import './extend/toc';
 
 @import 'materialize/sideNav';
 @import './extend/side-nav';

--- a/app/assets/stylesheets/mtl/extend/_toc.scss
+++ b/app/assets/stylesheets/mtl/extend/_toc.scss
@@ -1,0 +1,12 @@
+.table-of-contents {
+  a {
+    color: $mtl-toc-text;
+    &:hover {
+      color: lighten($mtl-toc-text, 20%);
+      border-color: $mtl-toc-border;
+    }
+    &.active {
+      border-color: $mtl-toc-border;
+    }
+  }
+}

--- a/lib/generators/mtl/templates/_variables.scss
+++ b/lib/generators/mtl/templates/_variables.scss
@@ -305,3 +305,6 @@ $mtl-layout-default-header-bg: color('shades', 'white');
 
 $mtl-layout-single-bg: color('grey', 'lighten-4');
 $mtl-layout-single-header-bg: color('grey', 'lighten-2');
+
+$mtl-toc-text: color('grey', 'darken-4');
+$mtl-toc-border: $primary-color;


### PR DESCRIPTION
Based on scrollspy and pushpin provided from MaterializeCSS an automated ToC generator in JS (with Turbolinks) support has been added.

![toc](https://cloud.githubusercontent.com/assets/83660/16998385/8102f1c2-4eb9-11e6-8d30-18d1833b8801.gif)

### Example markup

To generate the above ToC, the following markup was used:

```html
<div class="row">
  <div class="col s12 m9">
     <!-- add your sections with data-mtl-section="<Your title>" -->
     <section data-mtl-section="Introduction">
        <p>Llorem ipsum...</p>
     </section>

     <section data-mtl-section="Usage">
        <p>Llorem ipsum...</p>
     </section>

     <section data-mtl-section="Magic">
        <p>Llorem ipsum...</p>
     </section>
  </div>
  <div class="col m3 hide-on-small-only">
    <!-- mark the ToC with data-mtl-toc -->
    <ul data-mtl-toc="pin"></ul>
  </div>
</div>
```

#### CSS things

Required adding additional CSS to properly style this with variables
defined by in _variables.scss:

- $mtl-toc-text color value
- $mtl-toc-border color value (defaults to $primary-color)

@marcopluess please review the CSS + reference, Danke.
@lgavillet and @sled, please check the JS and reference, thanks.