### PR TITLE
Update to latest materialize-css version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Updated materialize-css to [171a9ef](https://github.com/Dogfalo/materialize/commit/171a9ef004b3145864ef975baa4cea8c0c06bf11) [#45]
 - Unify typography / headings to better conform to Material Design [#36, #39, #40]
 - Implement ToC based on pushpin and scrollspy [#36]
   This introduces a two new variables to properly style ToCs,

--- a/app/assets/stylesheets/mtl/layouts/_default.scss
+++ b/app/assets/stylesheets/mtl/layouts/_default.scss
@@ -146,11 +146,13 @@
 
     a {
       font-size: 1rem;
-      height: 40px;
-      line-height: 40px;
+      height: $sidenav-item-height;
+      line-height: $sidenav-item-height;
 
       .material-icons {
-        line-height: 40px;
+        width: $sidenav-item-height;
+        height: $sidenav-item-height;
+        line-height: $sidenav-item-height;
         margin-right: 0;
       }
     }

--- a/lib/generators/mtl/templates/_variables.scss
+++ b/lib/generators/mtl/templates/_variables.scss
@@ -219,7 +219,7 @@ $sidenav-font-size: 1rem !default;
 $sidenav-font-color: rgba(0,0,0,.87) !default;
 $sidenav-bg-color: #fff !default;
 $sidenav-padding: 16px !default;
-$sidenav-item-height: 48px !default;
+$sidenav-item-height: 40px !default;
 
 
 // 15. Photo Slider =========================================================
@@ -299,12 +299,12 @@ $progress-bar-color: $secondary-color !default;
 $mtl-sidenav-bg-active-color: color('blue', 'base') !default;
 $mtl-sidenav-font-active-color: #fff !default;
 
-$mtl-layout-default-bg: color('grey', 'lighten-5');
-$mtl-layout-default-text: color('grey', 'darken-4');
-$mtl-layout-default-header-bg: color('shades', 'white');
+$mtl-layout-default-bg: color('grey', 'lighten-5') !default;
+$mtl-layout-default-text: color('grey', 'darken-4') !default;
+$mtl-layout-default-header-bg: color('shades', 'white') !default;
 
-$mtl-layout-single-bg: color('grey', 'lighten-4');
-$mtl-layout-single-header-bg: color('grey', 'lighten-2');
+$mtl-layout-single-bg: color('grey', 'lighten-4') !default;
+$mtl-layout-single-header-bg: color('grey', 'lighten-2') !default;
 
-$mtl-toc-text: color('grey', 'darken-4');
-$mtl-toc-border: $primary-color;
+$mtl-toc-text: color('grey', 'darken-4') !default;
+$mtl-toc-border: $primary-color !default;

--- a/lib/mtl/version.rb
+++ b/lib/mtl/version.rb
@@ -1,5 +1,5 @@
 module Mtl
   VERSION = '0.1.0'.freeze
-  MATERIALIZE_VERSION = '0.97.6'.freeze
+  MATERIALIZE_VERSION = '0.97.7'.freeze
   ICONS_VERSION = '2.2.3'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
 
   "dependencies": {
-    "materialize-css": "https://github.com/Dogfalo/materialize.git#53c624d",
+    "materialize-css": "https://github.com/Dogfalo/materialize.git#171a9ef",
     "material-design-icons": "2.2.3"
   }
 }

--- a/vendor/assets/javascripts/materialize/collapsible.js
+++ b/vendor/assets/javascripts/materialize/collapsible.js
@@ -1,7 +1,9 @@
 (function ($) {
   $.fn.collapsible = function(options) {
     var defaults = {
-        accordion: undefined
+      accordion: undefined,
+      onOpen: undefined,
+      onClose: undefined
     };
 
     options = $.extend(defaults, options);
@@ -16,22 +18,22 @@
       var collapsible_type = $this.data("collapsible");
 
       // Turn off any existing event handlers
-       $this.off('click.collapse', '> li > .collapsible-header');
-       $panel_headers.off('click.collapse');
+      $this.off('click.collapse', '> li > .collapsible-header');
+      $panel_headers.off('click.collapse');
 
 
-       /****************
-       Helper Functions
-       ****************/
+      /****************
+      Helper Functions
+      ****************/
 
       // Accordion Open
       function accordionOpen(object) {
         $panel_headers = $this.find('> li > .collapsible-header');
         if (object.hasClass('active')) {
-            object.parent().addClass('active');
+          object.parent().addClass('active');
         }
         else {
-            object.parent().removeClass('active');
+          object.parent().removeClass('active');
         }
         if (object.parent().hasClass('active')){
           object.siblings('.collapsible-body').stop(true,false).slideDown({ duration: 350, easing: "easeOutQuart", queue: false, complete: function() {$(this).css('height', '');}});
@@ -41,31 +43,61 @@
         }
 
         $panel_headers.not(object).removeClass('active').parent().removeClass('active');
-        $panel_headers.not(object).parent().children('.collapsible-body').stop(true,false).slideUp(
-          {
-            duration: 350,
-            easing: "easeOutQuart",
-            queue: false,
-            complete:
-              function() {
-                $(this).css('height', '');
-              }
-          });
+
+        // Close previously open accordion elements.
+        $panel_headers.not(object).parent().children('.collapsible-body').stop(true,false).each(function() {
+          if ($(this).is(':visible')) {
+            $(this).slideUp({
+              duration: 350,
+              easing: "easeOutQuart",
+              queue: false,
+              complete:
+                function() {
+                  $(this).css('height', '');
+                  execCallbacks($(this).siblings('.collapsible-header'));
+                }
+            });
+          }
+        });
       }
 
       // Expandable Open
       function expandableOpen(object) {
         if (object.hasClass('active')) {
-            object.parent().addClass('active');
+          object.parent().addClass('active');
         }
         else {
-            object.parent().removeClass('active');
+          object.parent().removeClass('active');
         }
         if (object.parent().hasClass('active')){
           object.siblings('.collapsible-body').stop(true,false).slideDown({ duration: 350, easing: "easeOutQuart", queue: false, complete: function() {$(this).css('height', '');}});
         }
-        else{
+        else {
           object.siblings('.collapsible-body').stop(true,false).slideUp({ duration: 350, easing: "easeOutQuart", queue: false, complete: function() {$(this).css('height', '');}});
+        }
+      }
+
+      // Open collapsible. object: .collapsible-header
+      function collapsibleOpen(object) {
+        if (options.accordion || collapsible_type === "accordion" || collapsible_type === undefined) { // Handle Accordion
+          accordionOpen(object);
+        } else { // Handle Expandables
+          expandableOpen(object);
+        }
+
+        execCallbacks(object);
+      }
+
+      // Handle callbacks
+      function execCallbacks(object) {
+        if (object.hasClass('active')) {
+          if (typeof(options.onOpen) === "function") {
+            options.onOpen.call(this, object.parent());
+          }
+        } else {
+          if (typeof(options.onClose) === "function") {
+            options.onClose.call(this, object.parent());
+          }
         }
       }
 
@@ -97,8 +129,7 @@
 
       // Add click handler to only direct collapsible header children
       $this.on('click.collapse', '> li > .collapsible-header', function(e) {
-        var $header = $(this),
-            element = $(e.target);
+        var element = $(e.target);
 
         if (isChildrenOfPanelHeader(element)) {
           element = getPanelHeader(element);
@@ -106,25 +137,17 @@
 
         element.toggleClass('active');
 
-        if (options.accordion || collapsible_type === "accordion" || collapsible_type === undefined) { // Handle Accordion
-          accordionOpen(element);
-        } else { // Handle Expandables
-          expandableOpen(element);
-
-          if ($header.hasClass('active')) {
-            expandableOpen($header);
-          }
-        }
+        collapsibleOpen(element);
       });
 
+
       // Open first active
-      var $panel_headers = $this.find('> li > .collapsible-header');
       if (options.accordion || collapsible_type === "accordion" || collapsible_type === undefined) { // Handle Accordion
-        accordionOpen($panel_headers.filter('.active').first());
-      }
-      else { // Handle Expandables
+        collapsibleOpen($panel_headers.filter('.active').first());
+
+      } else { // Handle Expandables
         $panel_headers.filter('.active').each(function() {
-          expandableOpen($(this));
+          collapsibleOpen($(this));
         });
       }
 

--- a/vendor/assets/javascripts/materialize/dropdown.js
+++ b/vendor/assets/javascripts/materialize/dropdown.js
@@ -108,10 +108,16 @@
         }
 
         // Check for scrolling positioned container.
-        var scrollOffset = 0;
+        var scrollYOffset = 0;
+        var scrollXOffset = 0;
         var wrapper = origin.parent();
-        if (!wrapper.is('body') && wrapper[0].scrollHeight > wrapper[0].clientHeight) {
-          scrollOffset = wrapper[0].scrollTop;
+        if (!wrapper.is('body')) {
+          if (wrapper[0].scrollHeight > wrapper[0].clientHeight) {
+            scrollYOffset = wrapper[0].scrollTop;
+          }
+          if (wrapper[0].scrollWidth > wrapper[0].clientWidth) {
+            scrollXOffset = wrapper[0].scrollLeft;
+          }
         }
 
 
@@ -152,8 +158,8 @@
         // Position dropdown
         activates.css({
           position: 'absolute',
-          top: origin.position().top + verticalOffset + scrollOffset,
-          left: leftPosition
+          top: origin.position().top + verticalOffset + scrollYOffset,
+          left: leftPosition + scrollXOffset
         });
 
 

--- a/vendor/assets/javascripts/materialize/tooltip.js
+++ b/vendor/assets/javascripts/materialize/tooltip.js
@@ -66,7 +66,6 @@
           // Create backdrop
           backdrop = $('<div class="backdrop"></div>');
           backdrop.appendTo(tooltip);
-          backdrop.css({ top: 0, left:0 });
           return tooltip;
         };
         tooltipEl = renderTooltipEl();
@@ -77,7 +76,7 @@
         var started = false, timeoutRef;
         origin.on({'mouseenter.tooltip': function(e) {
           var showTooltip = function() {
-            console.log(tooltipPosition);
+            setAttributes();
             started = true;
             tooltipEl.velocity('stop');
             backdrop.velocity('stop');
@@ -91,7 +90,8 @@
             var tooltipWidth = tooltipEl.outerWidth();
             var tooltipVerticalMovement = '0px';
             var tooltipHorizontalMovement = '0px';
-            var scale_factor = 8;
+            var scaleXFactor = 8;
+            var scaleYFactor = 8;
             var targetTop, targetLeft, newCoordinates;
 
             if (tooltipPosition === "top") {
@@ -102,8 +102,10 @@
 
               tooltipVerticalMovement = '-10px';
               backdrop.css({
+                bottom: 0,
+                left: 0,
                 borderRadius: '14px 14px 0 0',
-                transformOrigin: '50% 90%',
+                transformOrigin: '50% 100%',
                 marginTop: tooltipHeight,
                 marginLeft: (tooltipWidth/2) - (backdrop.width()/2)
               });
@@ -116,6 +118,8 @@
 
               tooltipHorizontalMovement = '-10px';
               backdrop.css({
+                top: '-7px',
+                right: 0,
                 width: '14px',
                 height: '14px',
                 borderRadius: '14px 0 0 14px',
@@ -132,6 +136,8 @@
 
               tooltipHorizontalMovement = '+10px';
               backdrop.css({
+                top: '-7px',
+                left: 0,
                 width: '14px',
                 height: '14px',
                 borderRadius: '0 14px 14px 0',
@@ -147,6 +153,8 @@
               newCoordinates = repositionWithinScreen(targetLeft, targetTop, tooltipWidth, tooltipHeight);
               tooltipVerticalMovement = '+10px';
               backdrop.css({
+                top: 0,
+                left: 0,
                 marginLeft: (tooltipWidth/2) - (backdrop.width()/2)
               });
             }
@@ -158,21 +166,14 @@
             });
 
             // Calculate Scale to fill
-            scale_factor = tooltipWidth / 8;
-            if (scale_factor < 8) {
-              scale_factor = 8;
-            }
-            if (tooltipPosition === "right" || tooltipPosition === "left") {
-              scale_factor = tooltipWidth / 10;
-              if (scale_factor < 6)
-                scale_factor = 6;
-            }
+            scaleXFactor = Math.SQRT2 * tooltipWidth / parseInt(backdrop.css('width'));
+            scaleYFactor = Math.SQRT2 * tooltipHeight / parseInt(backdrop.css('height'));
 
             tooltipEl.velocity({ marginTop: tooltipVerticalMovement, marginLeft: tooltipHorizontalMovement}, { duration: 350, queue: false })
               .velocity({opacity: 1}, {duration: 300, delay: 50, queue: false});
             backdrop.css({ display: 'block' })
               .velocity({opacity:1},{duration: 55, delay: 0, queue: false})
-              .velocity({scale: scale_factor}, {duration: 300, delay: 0, queue: false, easing: 'easeInOutQuad'});
+              .velocity({scaleX: scaleXFactor, scaleY: scaleYFactor}, {duration: 300, delay: 0, queue: false, easing: 'easeInOutQuad'});
           };
 
           timeoutRef = setTimeout(showTooltip, tooltipDelay); // End Interval
@@ -189,7 +190,7 @@
             if (started !== true) {
               tooltipEl.velocity({
                 opacity: 0, marginTop: 0, marginLeft: 0}, { duration: 225, queue: false});
-              backdrop.velocity({opacity: 0, scale: 1}, {
+              backdrop.velocity({opacity: 0, scaleX: 1, scaleY: 1}, {
                 duration:225,
                 queue: false,
                 complete: function(){

--- a/vendor/assets/stylesheets/materialize/_cards.scss
+++ b/vendor/assets/stylesheets/materialize/_cards.scss
@@ -34,8 +34,11 @@
       max-height: 60%;
       overflow: hidden;
     }
-    .card-content {
+    .card-image + .card-content {
       max-height: 40%;
+    }
+    .card-content {
+      max-height: 100%;
       overflow: hidden;
     }
     .card-action {
@@ -58,6 +61,43 @@
     height: 500px;
   }
 
+  // Horizontal Cards
+  &.horizontal {
+    &.small, &.medium, &.large {
+      .card-image {
+        height: 100%;
+        max-height: none;
+        overflow: visible;
+
+        img {
+          height: 100%;
+        }
+      }
+    }
+
+    display: flex;
+
+    .card-image {
+      max-width: 50%;
+      img {
+        max-width: 100%;
+        width: auto;
+      }
+    }
+
+    .card-stacked {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      position: relative;
+
+      .card-content {
+        flex-grow: 1;
+      }
+    }
+  }
+
+  // Sticky Action Section
   &.sticky-action {
     .card-action {
       z-index: 2;
@@ -68,6 +108,8 @@
       padding-bottom: 64px;
     }
   }
+
+
 
 
   .card-image {

--- a/vendor/assets/stylesheets/materialize/_carousel.scss
+++ b/vendor/assets/stylesheets/materialize/_carousel.scss
@@ -45,6 +45,7 @@
   transform-origin: 0% 50%;
 
   .carousel-item {
+    display: none;
     width: 200px;
     height: 400px;
     position: absolute;

--- a/vendor/assets/stylesheets/materialize/_global.scss
+++ b/vendor/assets/stylesheets/materialize/_global.scss
@@ -61,23 +61,23 @@ a {
 .z-depth-0 {
   box-shadow: none !important;
 }
-.z-depth-1{
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
+.z-depth-1 {
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
 }
-.z-depth-1-half{
-  box-shadow: 0 5px 11px 0 rgba(0, 0, 0, 0.18), 0 4px 15px 0 rgba(0, 0, 0, 0.15);
+.z-depth-1-half {
+  box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.14), 0 1px 7px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -1px rgba(0, 0, 0, 0.2);
 }
-.z-depth-2{
-  box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+.z-depth-2 {
+  box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
 }
-.z-depth-3{
-  box-shadow: 0 12px 15px 0 rgba(0, 0, 0, 0.24), 0 17px 50px 0 rgba(0, 0, 0, 0.19);
+.z-depth-3 {
+  box-shadow: 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12), 0 3px 5px -1px rgba(0, 0, 0, 0.3);
 }
-.z-depth-4{
-  box-shadow: 0 16px 28px 0 rgba(0, 0, 0, 0.22), 0 25px 55px 0 rgba(0, 0, 0, 0.21);
+.z-depth-4 {
+  box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.3);
 }
-.z-depth-5{
-  box-shadow: 0 27px 24px 0 rgba(0, 0, 0, 0.2), 0 40px 77px 0 rgba(0, 0, 0, 0.22);
+.z-depth-5 {
+  box-shadow: 0 16px 24px 2px rgba(0, 0, 0, 0.14), 0 6px 30px 5px rgba(0, 0, 0, 0.12), 0 8px 10px -5px rgba(0, 0, 0, 0.3);
 }
 
 .hoverable {

--- a/vendor/assets/stylesheets/materialize/_modal.scss
+++ b/vendor/assets/stylesheets/materialize/_modal.scss
@@ -44,18 +44,18 @@
   }
 }
 .lean-overlay {
-    position: fixed;
-    z-index:999;
-    top: -100px;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    height: 125%;
-    width: 100%;
-    background: #000;
-    display: none;
+  position: fixed;
+  z-index: 999;
+  top: -100px;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  height: 125%;
+  width: 100%;
+  background: #000;
+  display: none;
 
-    will-change: opacity;
+  will-change: opacity;
 }
 
 // Modal with fixed action footer

--- a/vendor/assets/stylesheets/materialize/_sideNav.scss
+++ b/vendor/assets/stylesheets/materialize/_sideNav.scss
@@ -68,6 +68,7 @@
   li > a > [class^="mdi-"], li > a > [class*="mdi-"],
   li > a > i.material-icons {
     float: left;
+    height: $sidenav-item-height;
     line-height: $sidenav-item-height;
     margin: 0 ($sidenav-padding * 2) 0 0;
     width: $sidenav-item-height / 2;
@@ -212,7 +213,7 @@
 
   height: 120vh;
   background-color: rgba(0,0,0,.5);
-  z-index: 997;
+  z-index: 998;
 
   will-change: opacity;
 }

--- a/vendor/assets/stylesheets/materialize/_tooltip.scss
+++ b/vendor/assets/stylesheets/materialize/_tooltip.scss
@@ -1,22 +1,21 @@
 .material-tooltip {
-    padding: 10px 8px;
-    font-size: 1rem;
-    z-index: 2000;
-    background-color: transparent;
-    border-radius: 2px;
-    color: #fff;
-    min-height: 36px;
-    line-height: 120%;
-    opacity: 0;
-    display: none;
-    position: absolute;
-    text-align: center;
-    max-width: calc(100% - 4px);
-    overflow: hidden;
-    left:0;
-    top:0;
-    pointer-events: none;
-    will-change: top, left;
+  padding: 10px 8px;
+  font-size: 1rem;
+  z-index: 2000;
+  background-color: transparent;
+  border-radius: 2px;
+  color: #fff;
+  min-height: 36px;
+  line-height: 120%;
+  opacity: 0;
+  display: none;
+  position: absolute;
+  text-align: center;
+  max-width: calc(100% - 4px);
+  overflow: hidden;
+  left: 0;
+  top: 0;
+  pointer-events: none;
 }
 
 .backdrop {
@@ -25,10 +24,9 @@
   display: none;
   height: 7px;
   width: 14px;
-  border-radius: 0 0 14px 14px;
+  border-radius: 0 0 50% 50%;
   background-color: #323232;
   z-index: -1;
-  transform-origin: 50% 10%;
-
-  will-change: transform, opacity;
+  transform-origin: 50% 0%;
+  transform: translate3d(0,0,0);
 }


### PR DESCRIPTION
This updates to the [latest materialize-css version (171a9ef)](https://github.com/Dogfalo/materialize/commit/171a9ef004b3145864ef975baa4cea8c0c06bf11).

Found only one regression in how the icons in the sidebar are treated. Added a temporary fix in our `_default.scss`, it is important that in _variables.css the `$sidebar-item-height` is set to `40px` to match the previous styling. Once merged, I'd like to properly clean this up and streamline with #42 (to ensure we have same height, icon sizes, paddings, colors etc.).

/cc @marcopluess please review, danke.