### PR TITLE
Fix avatar class name collision

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Prefixed MTL avatar extension to `mtl-avatar` [#46]
 - Unify typography / headings to better conform to Material Design [#36, #39, #40]
 - Implement ToC based on pushpin and scrollspy [#36]
   This introduces a two new variables to properly style ToCs,

--- a/app/assets/stylesheets/mtl/extend/_avatars.scss
+++ b/app/assets/stylesheets/mtl/extend/_avatars.scss
@@ -1,17 +1,12 @@
-// vars/colors
-$avatar-size-small: 25px;
-$avatar-size-medium: 32px;
-$avatar-size-large: 52px;
-
 // avatars
-.avatar {
+.mtl-avatar {
   display: inline-block;
   border-radius: 50%;
-  height: $avatar-size-medium !important;
-  width: $avatar-size-medium !important;
+  height: $mtl-avatar-size-medium !important;
+  width: $mtl-avatar-size-medium !important;
   overflow: hidden;
   text-align: center;
-  line-height: $avatar-size-medium !important;
+  line-height: $mtl-avatar-size-medium !important;
   position: relative;
   font-size: 11px !important;
   font-weight: normal;
@@ -27,15 +22,15 @@ $avatar-size-large: 52px;
   }
 }
 
-.avatar.small {
-  height: $avatar-size-small !important;
-  width: $avatar-size-small !important;
-  line-height: $avatar-size-small !important;
+.mtl-avatar.small {
+  height: $mtl-avatar-size-small !important;
+  width: $mtl-avatar-size-small !important;
+  line-height: $mtl-avatar-size-small !important;
   font-size: 10px !important;
 }
-.avatar.large {
-  height: $avatar-size-large !important;
-  width: $avatar-size-large !important;
-  line-height: $avatar-size-large !important;
+.mtl-avatar.large {
+  height: $mtl-avatar-size-large !important;
+  width: $mtl-avatar-size-large !important;
+  line-height: $mtl-avatar-size-large !important;
   font-size: 15px !important;
 }

--- a/lib/generators/mtl/templates/_variables.scss
+++ b/lib/generators/mtl/templates/_variables.scss
@@ -308,3 +308,7 @@ $mtl-layout-single-header-bg: color('grey', 'lighten-2');
 
 $mtl-toc-text: color('grey', 'darken-4');
 $mtl-toc-border: $primary-color;
+
+$mtl-avatar-size-small: 25px;
+$mtl-avatar-size-medium: 32px;
+$mtl-avatar-size-large: 52px;

--- a/lib/mtl/rails/view_helpers.rb
+++ b/lib/mtl/rails/view_helpers.rb
@@ -230,7 +230,9 @@ module Mtl
       # @param options [Hash] Additional options that can be passed to `link_to`
       # @return [String] HTML safe `<a/>` tag
       def mtl_avatar_link(url, name, image_url = nil, options = {})
-        options[:class] = ['avatar', Mtl.effects, options.delete(:size), options[:class]].compact
+        options[:class] = [
+          'mtl-avatar', Mtl.effects, options.delete(:size), options[:class]
+        ].compact
         image = (image_url.present? ? image_tag(image_url, alt: name) : '')
         link_to image + mtl_avatar_initials(name), url, options
       end
@@ -243,7 +245,7 @@ module Mtl
       # @param options [Hash] Additional options that can be passed to `link_to`
       # @return [String] HTML safe `<span/>` tag
       def mtl_avatar(name, image_url = nil, options = {})
-        options[:class] = ['avatar', options.delete(:size), options[:class]].compact
+        options[:class] = ['mtl-avatar', options.delete(:size), options[:class]].compact
         image = (image_url.present? ? image_tag(image_url, alt: name) : '')
         content_tag :span, image + mtl_avatar_initials(name), options
       end

--- a/spec/mtl/rails/view_helpers_spec.rb
+++ b/spec/mtl/rails/view_helpers_spec.rb
@@ -86,34 +86,34 @@ RSpec.describe Mtl::Rails::ViewHelpers, dom: true do
   context '#mtl_avatar_link' do
     it 'renders an <a/> tag with initials and no image, if none provided' do
       expect(subject.mtl_avatar_link('/url', 'John Doe'))
-        .to eq '<a class="avatar waves-effect waves-light" href="/url">JD</a>'
+        .to eq '<a class="mtl-avatar waves-effect waves-light" href="/url">JD</a>'
     end
 
     it 'renders an <a/> tag with initials and an image, if an url is provided' do
       expect(subject.mtl_avatar_link('/url', 'John Doe', '/image_url.png'))
-        .to eq '<a class="avatar waves-effect waves-light" href="/url"><img alt="John Doe" src="/image_url.png" />JD</a>'
+        .to eq '<a class="mtl-avatar waves-effect waves-light" href="/url"><img alt="John Doe" src="/image_url.png" />JD</a>'
     end
 
     it 'renders a small avatar <a/> tag with initials and an image, if size: :small' do
       expect(subject.mtl_avatar_link('/url', 'John Doe', '/image_url.png', size: :small))
-        .to eq '<a class="avatar waves-effect waves-light small" href="/url"><img alt="John Doe" src="/image_url.png" />JD</a>'
+        .to eq '<a class="mtl-avatar waves-effect waves-light small" href="/url"><img alt="John Doe" src="/image_url.png" />JD</a>'
     end
   end
 
   context '#mtl_avatar' do
     it 'renders an <span/> tag with initials and no image, if none provided' do
       expect(subject.mtl_avatar('John Doe'))
-        .to eq '<span class="avatar">JD</span>'
+        .to eq '<span class="mtl-avatar">JD</span>'
     end
 
     it 'renders an <span/> tag with initials and an image, if an url is provided' do
       expect(subject.mtl_avatar('John Doe', '/image_url.png'))
-        .to eq '<span class="avatar"><img alt="John Doe" src="/image_url.png" />JD</span>'
+        .to eq '<span class="mtl-avatar"><img alt="John Doe" src="/image_url.png" />JD</span>'
     end
 
     it 'renders a large <span/> tag as an avatar, if size: :large' do
       expect(subject.mtl_avatar('John Doe', nil, size: :large))
-        .to eq '<span class="avatar large">JD</span>'
+        .to eq '<span class="mtl-avatar large">JD</span>'
     end
   end
 


### PR DESCRIPTION
Fixes the CSS class name collision with the `avatar` class as described in #44 

Changes:
- Prefixed our avatar extension with `mtl-`
- Made avatar sizes configurable:
```
$mtl-avatar-size-small: 25px;
$mtl-avatar-size-medium: 32px;
$mtl-avatar-size-large: 52px;
```