### PR TITLE
Add CSS class suport to header view helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Development 0.1.0
 - Made side-nav icons independent from the entry height pro proper spacing between icon and label [#52]
 - Bundle lodash.js as part of the mtl.js [#49]
 - Removed wierd side-nav divider margin [#51]
+- Added custom CSS class support for `mtl_header` [#50]
 - Support Rails 5, relax dependency `railities` [#38, #48]
 - Used flexbox fix to enable the content area over the full page height [#41]
 - Extended default layout coloring variables [#41]

--- a/app/views/mtl/header.html.erb
+++ b/app/views/mtl/header.html.erb
@@ -1,4 +1,4 @@
-<header class="mtl-layout-default-header">
+<header class="<%= mtl_class %>">
   <nav>
     <div class="nav-wrapper">
       <%- if mtl_back  %>

--- a/lib/mtl/rails/view_helpers.rb
+++ b/lib/mtl/rails/view_helpers.rb
@@ -232,14 +232,12 @@ module Mtl
       def mtl_header(title = translate('.title', default: 'Menu'), **options, &block)
         mtl_content = block_given? ? capture(&block) : nil
         mtl_class = ['mtl-layout-default-header', options[:class]].compact.flatten.join(' ')
-        mtl_back = options.fetch(:back, false)
-        mtl_menu = options.fetch(:menu, 'nav-menu')
 
         render file: 'mtl/header', locals: {
           mtl_content: mtl_content,
           mtl_title: title.presence,
-          mtl_back: mtl_back,
-          mtl_menu: mtl_menu,
+          mtl_back: options.fetch(:back, false),
+          mtl_menu: options.fetch(:menu, 'nav-menu'),
           mtl_class: mtl_class
         }
       end

--- a/lib/mtl/rails/view_helpers.rb
+++ b/lib/mtl/rails/view_helpers.rb
@@ -226,17 +226,21 @@ module Mtl
       # @param menu [String, Boolean] (HTML ID) references the id of the aside menu / default
       #   nav menu to show / hide on mobile devices. The default used is `nav-menu`.
       #   When set to `false`, this button is skipped.
+      # @param class [String, Array] (HTML CLASS) additional, custom css class on header
       # @yield Additional content to be rendered as part of the header
       # @return [String] HTML safe string
-      def mtl_header(title = translate('.title', default: 'Menu'),
-                     back: false, menu: 'nav-menu', &block)
+      def mtl_header(title = translate('.title', default: 'Menu'), **options, &block)
         mtl_content = block_given? ? capture(&block) : nil
+        mtl_class = ['mtl-layout-default-header', options[:class]].compact.flatten.join(' ')
+        mtl_back = options.fetch(:back, false)
+        mtl_menu = options.fetch(:menu, 'nav-menu')
 
         render file: 'mtl/header', locals: {
           mtl_content: mtl_content,
           mtl_title: title.presence,
-          mtl_back: back,
-          mtl_menu: menu
+          mtl_back: mtl_back,
+          mtl_menu: mtl_menu,
+          mtl_class: mtl_class
         }
       end
 

--- a/spec/mtl/rails/view_helpers_spec.rb
+++ b/spec/mtl/rails/view_helpers_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Mtl::Rails::ViewHelpers, dom: true do
     end
 
     it 'can pass in an array of custom css classes' do
-      expect(subject.mtl_header('Dashboard', class: ['something', 'anything']))
+      expect(subject.mtl_header('Dashboard', class: %w{something anything}))
         .to contain_dom '<header class="mtl-layout-default-header something anything">'
     end
   end

--- a/spec/mtl/rails/view_helpers_spec.rb
+++ b/spec/mtl/rails/view_helpers_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Mtl::Rails::ViewHelpers, dom: true do
       expect(subject.mtl_header('Dashboard') { subject.content_tag('div', 'Hello', class: 'foo') })
         .to contain_dom '<h1 class="page-title">Dashboard</h1><div class="foo">Hello</div>'
     end
+
+    it 'can pass in a custom css class' do
+      expect(subject.mtl_header('Dashboard', class: 'something'))
+        .to contain_dom '<header class="mtl-layout-default-header something">'
+    end
+
+    it 'can pass in an array of custom css classes' do
+      expect(subject.mtl_header('Dashboard', class: ['something', 'anything']))
+        .to contain_dom '<header class="mtl-layout-default-header something anything">'
+    end
   end
 
   context '#mtl_button' do


### PR DESCRIPTION
Adds the ability to pass in a custom CSS class to the header view helper, useful for scenarios where we want to apply custom styling to the header such as a `navbar-fixed`.