### PR TITLE
Configurable sidebar width and preventing overlap of fixed headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Made side nav width configurable by $mtl-layout-default-sidenav-width and added
+  a fix to prevent overlapping of fixed headers. [#54]
 - Added `data-mtl-submit` behaviour [#53]
 - Made side-nav icons independent from the entry height pro proper spacing between icon and label [#52]
 - Bundle lodash.js as part of the mtl.js [#49]

--- a/app/assets/stylesheets/mtl/layouts/_default.scss
+++ b/app/assets/stylesheets/mtl/layouts/_default.scss
@@ -5,7 +5,7 @@
 
   // sidebar logic
   main {
-    padding-left: 240px;
+    padding-left: $mtl-layout-default-sidenav-width;
     min-height: 100%;
     display: flex;
     flex-direction: column;

--- a/app/assets/stylesheets/mtl/layouts/_default.scss
+++ b/app/assets/stylesheets/mtl/layouts/_default.scss
@@ -149,7 +149,7 @@
 
   // sidebar
   .side-nav {
-    width: 240px;
+    width: $mtl-layout-default-sidenav-width;
     background-color: $mtl-layout-default-sidenav-bg;
     color: $mtl-layout-default-sidenav-text;
 

--- a/app/assets/stylesheets/mtl/layouts/_default.scss
+++ b/app/assets/stylesheets/mtl/layouts/_default.scss
@@ -101,6 +101,17 @@
     }
   }
   //&-back {}
+
+  // prevent overlap on the right in fixed navbar mode
+  @media #{$large-and-up} {
+    &.navbar-fixed {
+      > nav {
+        width: auto;
+        left: $mtl-layout-default-sidenav-width;
+        right: 0;
+      }
+    }
+  }
 }
 
 // content area

--- a/lib/generators/mtl/templates/_variables.scss
+++ b/lib/generators/mtl/templates/_variables.scss
@@ -302,6 +302,8 @@ $mtl-sidenav-bg-active-color: color('blue', 'base') !default;
 $mtl-sidenav-font-active-color: #fff !default;
 
 // default layout
+$mtl-layout-default-sidenav-width: 240px !default;
+
 $mtl-layout-default-bg: color('grey', 'lighten-5') !default;
 $mtl-layout-default-text: color('grey', 'darken-4') !default;
 


### PR DESCRIPTION
I added a variable `$mtl-layout-default-sidenav-width` which allows to configure the sidebar width. However the primary reason is that in case of a fixed header there was an overlap on the right side due to the combination of `width: 100%;` and a left padding (sidebar).

The specific use case is something like:

```
= mtl_header class: 'navbar-fixed' do
  %ul.right
    %li
      = mtl_button 'Save', '#'
```
In this case the button disappears due to an overflow to the right and is not visible

@marcopluess Do you approve the CSS? 😄 
