### PR TITLE
Remove default borders and other coulouring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Removed default table extends to disable coulouring and borders [#64]
 - Exposed label styles for the h5 element [#61, #62]
 - Introduced JS helpers within MTL namespace (icon helpers) [#60]
 - Added file card helper for file collections [#58]

--- a/app/assets/stylesheets/mtl/extend/_global.scss
+++ b/app/assets/stylesheets/mtl/extend/_global.scss
@@ -1,16 +1,7 @@
-$table-border-color-head: #eee;
-
 td,
 th {
   border-radius: 0;
 }
-th {
-  background-color: $table-head-bg;
-}
-tbody tr {
-  border-bottom: 1px solid $table-border-color;
-}
-
 
 table {
   &.responsive-table {
@@ -22,12 +13,6 @@ table {
     }
 
     thead {
-      border-color: $table-border-color-head;
-
-      @media #{$medium-and-down} {
-        border-color: $table-border-color;
-      }
-
       tr {
         padding: 0;
 


### PR DESCRIPTION
Removing the default styles added to the tables, to allow a finer control on table displays.

Two main changes: 
1) Removed the default background color on the table heads, linked via $table-head-bg. Now, just use a colouring class on the %thead tag. Example: 
```haml
%table
  %thead.grey.lighten-4
    %tr
    ...
```

2) Removed the default borders on every table row, linked via $table-border-color. Now just use the class `bordered` provided by materialize. Example: 
```haml
%table.bordered
  %thead
    %tr
    ...
```

/cc @sled @marcopluess 
