### PR TITLE
Truncate long filenames and titles on file cards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Truncate long file names and titles on file cards [#70]
 - Render preview of file cards in a modal dialog [#65]
 - Basic template registry for lodash templates [#65]
 - PDFObject dependency [#65]

--- a/app/assets/stylesheets/mtl/extend/_collection-files.scss
+++ b/app/assets/stylesheets/mtl/extend/_collection-files.scss
@@ -41,12 +41,10 @@ $mtl-collection-file-text-secondary: color('grey', 'base');
       display: block;
       font-size: 13px;
       line-height: 16px;
-    }
-    > strong {
       color: $mtl-collection-file-text-primary;
     }
+
     > span {
-      color: $mtl-collection-file-text-secondary;
       vertical-align: middle;
 
       // icon override 1
@@ -55,6 +53,10 @@ $mtl-collection-file-text-secondary: color('grey', 'base');
         height: 16px;
         font-size: 20px;
         vertical-align: middle;
+      }
+
+      &.secondary {
+        color: $mtl-collection-file-text-secondary;
       }
     }
 

--- a/lib/mtl/rails/card_file_presenter.rb
+++ b/lib/mtl/rails/card_file_presenter.rb
@@ -31,12 +31,16 @@ module Mtl
       private
 
       def label(filename, title = nil)
-        return filename unless title
-        view.safe_join [view.content_tag(:strong, title), filename]
+        return filename_tag(filename) unless title
+        view.safe_join [view.content_tag(:strong, title, class: 'truncate'), filename_tag(filename)]
+      end
+
+      def filename_tag(filename)
+        view.content_tag(:span, filename, class: 'truncate')
       end
 
       def infos(params)
-        view.content_tag :span, icon(params[:type]) + " #{params[:type].upcase}", class: 'grey-text'
+        view.content_tag :span, icon(params[:type]) + " #{params[:type].upcase}", class: 'secondary'
       end
 
       def icon(type)

--- a/spec/mtl/rails/card_file_presenter_spec.rb
+++ b/spec/mtl/rails/card_file_presenter_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
 
   context '#render' do
     it 'renders a basic file card with filename and href' do
+      puts subject.render('Document Dolorem.jpg', '/path/to/file.jpg')
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg')).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel " href="/path/to/file.jpg">
-          Document Dolorem.jpg
-          <span class="grey-text">
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
             <i class="material-icons red-text">image</i>
             JPG
           </span>
@@ -27,9 +28,9 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
     it 'renders a file card with filename, href and a custom title' do
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', title: 'foo')).to match_dom <<-HTML
         <a title="foo" target="_blank" class="card-panel " href="/path/to/file.jpg">
-          <strong>foo</strong>
-          Document Dolorem.jpg
-          <span class="grey-text">
+          <strong class="truncate">foo</strong>
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
             <i class="material-icons red-text">image</i>
             JPG
           </span>
@@ -40,8 +41,8 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
     it 'renders a file card with filename, href and a custom type' do
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', type: 'bar')).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel " href="/path/to/file.jpg">
-          Document Dolorem.jpg
-          <span class="grey-text">
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
             <i class="material-icons blue-text">insert_drive_file</i>
             BAR
           </span>
@@ -52,8 +53,8 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
     it 'renders a file card with filename, href and a custom preview' do
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', preview: '/path/to/preview.jpg')).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel card-panel-image" style="background-image: url(/path/to/preview.jpg)" href="/path/to/file.jpg">
-          Document Dolorem.jpg
-          <span class="grey-text">
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
             <i class="material-icons red-text">image</i>
             JPG
           </span>
@@ -64,8 +65,8 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
     it 'renders a file card with filename, href and a custom custom delete' do
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', delete: '/path/to/delete/the/file')).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel " href="/path/to/file.jpg">
-          Document Dolorem.jpg
-          <span class="grey-text">
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
             <i class="material-icons red-text">image</i>
             JPG
           </span>
@@ -78,8 +79,8 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
       p(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', delete: '/path/to/delete/the/file', confirm: 'sure?'))
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', delete: '/path/to/delete/the/file', confirm: 'sure?')).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel " href="/path/to/file.jpg">
-          Document Dolorem.jpg
-          <span class="grey-text">
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
             <i class="material-icons red-text">image</i>
             JPG
           </span>
@@ -91,8 +92,8 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
     it 'renders a file card with filename, href and document modal options' do
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', modal: true)).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel " data-mtl-document-modal="open" data-mtl-document-name="Document Dolorem.jpg" href="/path/to/file.jpg">
-          Document Dolorem.jpg
-          <span class="grey-text">
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
             <i class="material-icons red-text">image</i>
             JPG
           </span>


### PR DESCRIPTION
Truncates long filenames and titles on file cards by adding a "truncate" class and wrapping the filename in a `<span>` tag. See Issue #67 for reference.