### PR TITLE
Add support for custom data attributes on file cards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ ChangeLog
 Development 0.1.0
 ------------------
 
+- Add support for custom data attributes on file cards [#73]
 - Truncate long file names and titles on file cards [#70]
 - Render preview of file cards in a modal dialog [#65]
 - Basic template registry for lodash templates [#65]

--- a/lib/mtl/rails/card_file_presenter.rb
+++ b/lib/mtl/rails/card_file_presenter.rb
@@ -58,8 +58,7 @@ module Mtl
 
       def data(filename, params)
         data = params[:data] || {}
-        data = data.merge(modal_data(filename, params))
-        data
+        data.merge(modal_data(filename, params))
       end
 
       def modal_data(filename, params)

--- a/lib/mtl/rails/card_file_presenter.rb
+++ b/lib/mtl/rails/card_file_presenter.rb
@@ -18,7 +18,7 @@ module Mtl
                      title: params[:title] || filename,
                      target: '_blank',
                      class: ['card-panel', params[:preview] ? 'card-panel-image' : nil],
-                     data: modal(filename, params),
+                     data: data(filename, params),
                      style: if params[:preview]
                               "background-image: url(#{URI.encode(params[:preview])})"
                             end
@@ -56,8 +56,14 @@ module Mtl
         view.mtl_icon :close, class: 'close', data: data.reject { |_, v| v.blank? }
       end
 
-      def modal(filename, params)
-        { mtl_document_modal: 'open', mtl_document_name: filename } if params.delete(:modal)
+      def data(filename, params)
+        data = params[:data] || {}
+        data = data.merge(modal_data(filename)) if params[:modal]
+        data
+      end
+
+      def modal_data(filename)
+        { mtl_document_modal: 'open', mtl_document_name: filename }
       end
     end
   end

--- a/lib/mtl/rails/card_file_presenter.rb
+++ b/lib/mtl/rails/card_file_presenter.rb
@@ -58,11 +58,12 @@ module Mtl
 
       def data(filename, params)
         data = params[:data] || {}
-        data = data.merge(modal_data(filename)) if params[:modal]
+        data = data.merge(modal_data(filename, params))
         data
       end
 
-      def modal_data(filename)
+      def modal_data(filename, params)
+        return {} unless params[:modal]
         { mtl_document_modal: 'open', mtl_document_name: filename }
       end
     end

--- a/spec/mtl/rails/card_file_presenter_spec.rb
+++ b/spec/mtl/rails/card_file_presenter_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
 
   context '#render' do
     it 'renders a basic file card with filename and href' do
-      puts subject.render('Document Dolorem.jpg', '/path/to/file.jpg')
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg')).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel " href="/path/to/file.jpg">
           <span class="truncate">Document Dolorem.jpg</span>
@@ -76,7 +75,6 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
     end
 
     it 'renders a file card with filename, href and a custom custom delete and a confirm' do
-      p(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', delete: '/path/to/delete/the/file', confirm: 'sure?'))
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', delete: '/path/to/delete/the/file', confirm: 'sure?')).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel " href="/path/to/file.jpg">
           <span class="truncate">Document Dolorem.jpg</span>
@@ -92,6 +90,30 @@ RSpec.describe Mtl::Rails::CardFilePresenter, dom: true do
     it 'renders a file card with filename, href and document modal options' do
       expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', modal: true)).to match_dom <<-HTML
         <a title="Document Dolorem.jpg" target="_blank" class="card-panel " data-mtl-document-modal="open" data-mtl-document-name="Document Dolorem.jpg" href="/path/to/file.jpg">
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
+            <i class="material-icons red-text">image</i>
+            JPG
+          </span>
+        </a>
+      HTML
+    end
+
+    it 'renders a file card with filename, href and custom data attributes' do
+      expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', data: { something: '42' })).to match_dom <<-HTML
+        <a title="Document Dolorem.jpg" target="_blank" class="card-panel " data-something="42" href="/path/to/file.jpg">
+          <span class="truncate">Document Dolorem.jpg</span>
+          <span class="secondary">
+            <i class="material-icons red-text">image</i>
+            JPG
+          </span>
+        </a>
+      HTML
+    end
+
+    it 'renders a file card with filename, href, document modal options and custom data attributes' do
+      expect(subject.render('Document Dolorem.jpg', '/path/to/file.jpg', modal: true, data: { something: '42' })).to match_dom <<-HTML
+        <a title="Document Dolorem.jpg" target="_blank" class="card-panel " data-something="42" data-mtl-document-modal="open" data-mtl-document-name="Document Dolorem.jpg" href="/path/to/file.jpg">
           <span class="truncate">Document Dolorem.jpg</span>
           <span class="secondary">
             <i class="material-icons red-text">image</i>


### PR DESCRIPTION
Allows you to pass in custom data attributes like this:

`mtl_card_file('example.jpg', '/example.jpg', data: { something: 42 })`

The data attribute is added to the outer most element of the file card e.g:

```
<a title="example.jpg" target="_blank" class="card-panel" data-something="42" href="/example.jpg">
    ... file card body ...
</a>
```
