### PR TITLE
Context fix for header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+Next release
+------------
+- Context fix for header #97
+
 Version 1.1.4
 ------------
 - Added navbar helper #94 #96

--- a/app/assets/stylesheets/mtl/all.scss
+++ b/app/assets/stylesheets/mtl/all.scss
@@ -13,6 +13,7 @@
 @import './extend/grid';
 
 @import 'materialize/navbar';
+@import './extend/navbar';
 
 // @import 'materialize/roboto';
 @import './extend/roboto-rails'; // using asset_url's

--- a/app/assets/stylesheets/mtl/extend/_navbar.scss
+++ b/app/assets/stylesheets/mtl/extend/_navbar.scss
@@ -1,0 +1,3 @@
+.navbar-fixed.navbar-fixed-extended {
+  height: 112px;
+}

--- a/app/views/mtl/header.html.erb
+++ b/app/views/mtl/header.html.erb
@@ -1,5 +1,5 @@
 <header class="<%= mtl_class %>">
-  <%= mtl_navbar fixed: mtl_fixed do |nav| %>
+  <%= mtl_nav.render fixed: mtl_fixed do |nav| %>
     <%- if mtl_back  %>
       <%= link_to mtl_back, class: 'mtl-layout-default-header-back left' do %>
         <i class="material-icons">arrow_back</i>
@@ -17,7 +17,7 @@
     <%- end %>
 
     <%- if mtl_content %>
-      <%= capture(nav, &mtl_content) %>
+      <%= mtl_content %>
     <%- end %>
   <%- end %>
 </header>

--- a/lib/mtl/rails/navbar_presenter.rb
+++ b/lib/mtl/rails/navbar_presenter.rb
@@ -16,9 +16,8 @@ module Mtl
                                                      render_extended(@extended_block, @extended_options)].compact),
                                class: @extended_block ? 'nav-extended' : nil
 
-        nav = view.content_tag :div, nav, class: ['navbar-fixed',
-                                                  @extended_block ? 'navbar-fixed-extended' : nil] if options[:fixed]
-        nav
+        return nav unless options[:fixed]
+        view.content_tag :div, nav, class: ['navbar-fixed', @extended_block ? 'navbar-fixed-extended' : nil]
       end
 
       def extended(options = {}, &block)

--- a/lib/mtl/rails/navbar_presenter.rb
+++ b/lib/mtl/rails/navbar_presenter.rb
@@ -13,16 +13,17 @@ module Mtl
 
       def render(options = {}, &block)
         nav = view.content_tag :nav, view.safe_join([render_main(options, &block),
-                                                     render_extended(@extended_options, &@extended_block)].compact),
+                                                     render_extended(@extended_block, @extended_options)].compact),
                                class: @extended_block ? 'nav-extended' : nil
 
-        nav = view.content_tag :div, nav, class: 'navbar-fixed' if options[:fixed]
+        nav = view.content_tag :div, nav, class: ['navbar-fixed',
+                                                  @extended_block ? 'navbar-fixed-extended' : nil] if options[:fixed]
         nav
       end
 
       def extended(options = {}, &block)
         @extended_options = options
-        @extended_block = block
+        @extended_block = view.capture(&block)
         nil
       end
 
@@ -32,9 +33,9 @@ module Mtl
         view.content_tag(:div, view.capture(self, &block), class: [options[:class], 'nav-wrapper'].flatten.compact)
       end
 
-      def render_extended(options = {}, &block)
-        return unless block_given?
-        view.content_tag(:div, view.capture(&block), class: [options[:class], 'nav-content'].flatten.compact)
+      def render_extended(content, options = {})
+        return unless content.presence
+        view.content_tag(:div, content, class: [options[:class], 'nav-content'].flatten.compact)
       end
     end
   end

--- a/lib/mtl/rails/view_helpers.rb
+++ b/lib/mtl/rails/view_helpers.rb
@@ -362,14 +362,16 @@ module Mtl
       # @return [String] HTML safe string
       def mtl_header(title = translate('.title', default: 'Menu'), **options, &block)
         mtl_class = ['mtl-layout-default-header', options[:class]].compact.flatten.join(' ')
+        mtl_nav = NavbarPresenter.new(self)
 
         render file: 'mtl/header', locals: {
-          mtl_content: block,
           mtl_title: title.presence,
           mtl_back: options.fetch(:back, false),
           mtl_menu: options.fetch(:menu, 'nav-menu'),
           mtl_fixed: options.fetch(:fixed, false),
-          mtl_class: mtl_class
+          mtl_class: mtl_class,
+          mtl_nav: mtl_nav,
+          mtl_content: capture(mtl_nav, &block)
         }
       end
 

--- a/lib/mtl/rails/view_helpers.rb
+++ b/lib/mtl/rails/view_helpers.rb
@@ -364,15 +364,10 @@ module Mtl
         mtl_class = ['mtl-layout-default-header', options[:class]].compact.flatten.join(' ')
         mtl_nav = NavbarPresenter.new(self)
 
-        render file: 'mtl/header', locals: {
-          mtl_title: title.presence,
-          mtl_back: options.fetch(:back, false),
-          mtl_menu: options.fetch(:menu, 'nav-menu'),
-          mtl_fixed: options.fetch(:fixed, false),
-          mtl_class: mtl_class,
-          mtl_nav: mtl_nav,
-          mtl_content: capture(mtl_nav, &block)
-        }
+        render file: 'mtl/header', locals: { mtl_title: title.presence, mtl_back: options.fetch(:back, false),
+                                             mtl_menu: options.fetch(:menu, 'nav-menu'),
+                                             mtl_fixed: options.fetch(:fixed, false), mtl_class: mtl_class,
+                                             mtl_nav: mtl_nav, mtl_content: capture(mtl_nav, &block) }
       end
 
       # Renders an avatar link, for the given url with the name's initials

--- a/lib/mtl/rails/view_helpers.rb
+++ b/lib/mtl/rails/view_helpers.rb
@@ -363,11 +363,11 @@ module Mtl
       def mtl_header(title = translate('.title', default: 'Menu'), **options, &block)
         mtl_class = ['mtl-layout-default-header', options[:class]].compact.flatten.join(' ')
         mtl_nav = NavbarPresenter.new(self)
-
+        mtl_content = block_given? ? capture(mtl_nav, &block) : nil
         render file: 'mtl/header', locals: { mtl_title: title.presence, mtl_back: options.fetch(:back, false),
                                              mtl_menu: options.fetch(:menu, 'nav-menu'),
                                              mtl_fixed: options.fetch(:fixed, false), mtl_class: mtl_class,
-                                             mtl_nav: mtl_nav, mtl_content: capture(mtl_nav, &block) }
+                                             mtl_nav: mtl_nav, mtl_content: mtl_content }
       end
 
       # Renders an avatar link, for the given url with the name's initials

--- a/spec/mtl/rails/navbar_presenter_spec.rb
+++ b/spec/mtl/rails/navbar_presenter_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Mtl::Rails::NavbarPresenter, dom: true do
 
         'Hello'
       end).to match_dom <<-HTML
-        <div class="navbar-fixed">
+        <div class="navbar-fixed navbar-fixed-extended">
           <nav class="nav-extended">
             <div class="nav-wrapper">
               Hello


### PR DESCRIPTION
The view was delegated to mtl/header instead of the calling view, which created issues using 'I18n.t' or other 'virtual_path' based helpers 