### PR TITLE
added generic margin helpers as new release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,21 +1,25 @@
 ChangeLog
 =========
 
+Version 1.1.6
+-------------
+- Add generic margin-helper classes.
+
 Version 1.1.5
-------------
+-------------
 - Context fix for header #97
 - Switch support for simple_form #98
 
 Version 1.1.4
-------------
+-------------
 - Added navbar helper #94 #96
 
 Version 1.1.3
-------------
+-------------
 Yanked.
 
 Version 1.1.2
-------------
+-------------
 - Fix unit calculation problem #92
 - Fix 1.1.1 bugs #91
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -117,6 +117,65 @@ views.
 
 ## CSS extensions
 
+### Generic margin helper classes
+
+To be as flexible as possible, we provide generic css classes to control the vertical space between two elements:
+
+<table>
+  <thead>
+    <th>class-name</th>
+    <th>margin-top</th>
+    <th>margin-bottom</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>margin-<b>lg</b></td>
+      <td>40px</td>
+      <td>40px</td>
+    </tr>
+    <tr>
+      <td>margin-<b>md</b></td>
+      <td>20px</td>
+      <td>20px</td>
+    </tr>
+    <tr>
+      <td>margin-<b>md</b></td>
+      <td>10px</td>
+      <td>10px</td>
+    </tr>
+    <tr>
+      <td>margin-<b>top-lg</b></td>
+      <td>40px</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>margin-<b>top-md</b></td>
+      <td>20px</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>margin-<b>top-md</b></td>
+      <td>10px</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>margin-<b>bottom-lg</b></td>
+      <td>&nbsp;</td>
+      <td>40px</td>
+    </tr>
+    <tr>
+      <td>margin-<b>bottom-md</b></td>
+      <td>&nbsp;</td>
+      <td>20px</td>
+    </tr>
+    <tr>
+      <td>margin-<b>bottom-md</b></td>
+      <td>&nbsp;</td>
+      <td>10px</td>
+    </tr>
+  </tbody>
+</table>
+
 
 ### Suffixes for single line inputs
 

--- a/app/assets/stylesheets/mtl/extend/_global.scss
+++ b/app/assets/stylesheets/mtl/extend/_global.scss
@@ -67,6 +67,38 @@ table {
   }
 }
 
+// margin helpers
+$margin-lg: 40px !important;
+$margin-md: 20px !important;
+$margin-sm: 10px !important;
+
+.margin-lg,
+.margin-top-lg {
+  margin-top: $margin-lg;
+}
+.margin-lg,
+.margin-bottom-lg {
+  margin-bottom: $margin-lg;
+}
+
+.margin-md,
+.margin-top-md {
+  margin-top: $margin-md;
+}
+.margin-md,
+.margin-bottom-md {
+  margin-bottom: $margin-md;
+}
+
+.margin-sm,
+.margin-top-sm {
+  margin-top: $margin-sm;
+}
+.margin-sm,
+.margin-bottom-sm {
+  margin-bottom: $margin-sm;
+}
+
 // horizontal ruler
 hr {
   line-height: 0;
@@ -74,4 +106,17 @@ hr {
   border-color: $table-border-color;
   border-width: 0 0 1px;
   border-style: solid;
+
+  &.margin-lg,
+  &.margin-top-lg {
+    margin-top: $margin-lg - 10px;
+  }
+  &.margin-md,
+  &.margin-top-md {
+    margin-top: $margin-md - 10px;
+  }
+  &.margin-sm,
+  &.margin-top-sm {
+    margin-top: $margin-sm - 10px;
+  }
 }

--- a/lib/mtl/version.rb
+++ b/lib/mtl/version.rb
@@ -1,5 +1,5 @@
 module Mtl
-  VERSION = '1.1.5'.freeze
+  VERSION = '1.1.6'.freeze
   MATERIALIZE_VERSION = '0.98.0'.freeze
   ICONS_VERSION = '2.2.3'.freeze
   LODASH_VERSION = '4.14.1'.freeze


### PR DESCRIPTION
implemented generic margin classes for better content spacing control in the application. the original mtl implementation lacks of options.

for the exact values and available classes check the *yardoc*.