### PR TITLE
Use interpolation for variables inside calc()

### DIFF
--- a/app/assets/stylesheets/mtl/extend/_chips.scss
+++ b/app/assets/stylesheets/mtl/extend/_chips.scss
@@ -15,9 +15,9 @@
   }
 
   .close {
-    font-size: calc($chip-font-size + 3px);
+    font-size: calc(#{$chip-font-size} + 3px);
     height: $chip-height;
     line-height: $chip-line-height;
-    padding-left: calc($chip-font-size + 3px) / 2;
+    padding-left: calc(#{$chip-font-size} + 3px) / 2;
   }
 }


### PR DESCRIPTION
Until now this was not compiled properly, i.e the output was

```
/* line 17, /Users/xxx/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/mtl-1.1.6/app/assets/stylesheets/mtl/extend/_chips.scss */
.chip .close {
  font-size: calc($chip-font-size + 3px);
  height: 22px;
  line-height: 23px;
  padding-left: calc($chip-font-size + 3px)/2;
}
```